### PR TITLE
Bugfix/nextAll

### DIFF
--- a/curtain.css
+++ b/curtain.css
@@ -23,6 +23,6 @@ html{
 }
 .curtains>li:first-child{z-index:2;}
 
-.curtains>li:first-child, .curtains>li:nth-child(1){
+.curtains>li:first-child, .curtains>li:nth-child(2){
     display: block;
 }

--- a/curtain.css
+++ b/curtain.css
@@ -12,7 +12,7 @@ html{
 .curtains>li{
     background: white;
     position: fixed;
-    display:block;
+    display:none;
     top: 0;
     left: 0;
     width: 100%;
@@ -22,3 +22,7 @@ html{
     -webkit-backface-visibility:hidden; /* Remove if you got display issues */
 }
 .curtains>li:first-child{z-index:2;}
+
+.curtains>li:first-child, .curtains>li:nth-child(1){
+    display: block;
+}

--- a/curtain.js
+++ b/curtain.js
@@ -266,7 +266,7 @@
 
                 $current.removeClass('current')
                     .css({display:'none'})
-                    .next().addClass('current').nextAll().css({display:'block'});
+                    .next().addClass('current').nextAll(':lt('+2+')').css({display:'block'});
             }
 
 


### PR DESCRIPTION
Currently, a large number of slides causes crippling performance in Chrome (and I think IE).

It seems that Chrome can't handle a lot of stacked (z-index) slides that are "visible" (display: block).

I have added a limit to the nextAll selector that sets all the next slides to display: block.  Now, it only acts on the next 2 slides.

Additionally, I have modified curtain.css to hide all but the first 2 slides by default.

These fixes took my project from unusable to lightning fast in Chrome and IE9, and also improved load time and performance in Firefox and Safari.
