### PR TITLE
Easing Option

### DIFF
--- a/curtain.js
+++ b/curtain.js
@@ -17,7 +17,8 @@
             scrollButtons: {},
             controls: null,
             curtainLinks: '.curtain-links',
-            enableKeys: true
+            enableKeys: true,
+            easing: 'swing'
         };
 
     // The actual plugin constructor
@@ -84,7 +85,7 @@
                     var position = $(newEl).attr('data-position') || null;
                     self.scrollEl.animate({
                         scrollTop:position
-                    }, self.options.scrollSpeed);
+                    }, self.options.scrollSpeed, self.options.easing);
                 }
             });
 
@@ -181,23 +182,23 @@
                 if(position){
                     self.scrollEl.animate({
                         scrollTop:position
-                    }, this.options.scrollSpeed);
+                    }, this.options.scrollSpeed, this.options.easing);
                 }
 
             } else if(direction === 'top'){
                 self.scrollEl.animate({
                     scrollTop:0
-                }, self.options.scrollSpeed);
+                }, self.options.scrollSpeed, self.options.easing);
             } else if(direction === 'bottom'){
                 self.scrollEl.animate({
                     scrollTop:self.options.bodyHeight
-                }, self.options.scrollSpeed);
+                }, self.options.scrollSpeed, self.options.easing);
             } else {
                 position = $("#"+direction).attr('data-position') || null;
                 if(position){
                     self.scrollEl.animate({
                         scrollTop:position
-                    }, this.options.scrollSpeed);
+                    }, this.options.scrollSpeed, this.options.easing);
                 }
             }
             
@@ -406,7 +407,7 @@
                     if(position){
                         self.scrollEl.animate({
                             scrollTop:position
-                        }, self.options.scrollSpeed);
+                        }, self.options.scrollSpeed, self.options.easing);
                     }
                     return false;
                 });


### PR DESCRIPTION
This feature adds an easing option to specify the easing function used by jQuery animate calls.

It defaults to 'swing', the jQuery default.

As jQuery only comes with 2 options by default ('swing' and 'linear'), the idea is that this would be used with the jQuery easing plugin or similar to allow for slick easing methods like easeOutQuart.
