### PR TITLE
Fixed IE8 bug in Issue #13

### DIFF
--- a/curtain.js
+++ b/curtain.js
@@ -150,14 +150,17 @@
                         callback();
                         return false;
                     }
-                    var img = new Image();
-                    $(img).attr('src',images[imagesLoaded]).load(function(){
-                    imagesLoaded++;
-                    if(imagesLoaded == images.length)
-                        callback();
-                    else
-                        loadAllImages(callback);
-                    });
+
+                    var img = new Image();					
+                    $(img).load(function() {
+                    	imagesLoaded++;
+	                    if(imagesLoaded == images.length)
+	                        callback();
+	                    else
+	                        loadAllImages(callback);
+	                });
+		
+					img.src = images[imagesLoaded];
                 };
 
             self.$element.find('img').each(function(i,el){
@@ -465,12 +468,22 @@
             }
 
             if ("onhashchange" in window) {
-                window.addEventListener("hashchange", function(){
-                    if(self._ignoreHashChange === false){
-                        self.isHashIsOnList(location.hash.substring(1));
-                    }
-                    self._ignoreHashChange = false;
-                }, false);
+				if(!window.addEventListener)
+				{
+					window.attachEvent("hashchange", function(){
+	                    if(self._ignoreHashChange === false){
+	                        self.isHashIsOnList(location.hash.substring(1));
+	                    }
+	                    self._ignoreHashChange = false;
+	                });	
+				} else {
+					window.addEventListener("hashchange", function(){
+	                    if(self._ignoreHashChange === false){
+	                        self.isHashIsOnList(location.hash.substring(1));
+	                    }
+	                    self._ignoreHashChange = false;
+	                }, false);
+				}
             }
         },
         setBodyHeight: function(){


### PR DESCRIPTION
The load event on the image loading wasn't being called reliably when using jQuery's attr() method. So I changed it to use DOM 0 src property setting.
Added if-else branch to use proper event listener (addEventListener or attachEvent).
